### PR TITLE
add generic timestamp

### DIFF
--- a/lib/src/org/model/org_timestamp.dart
+++ b/lib/src/org/model/org_timestamp.dart
@@ -14,12 +14,12 @@ class OrgDiaryTimestamp extends OrgLeafNode with SingleContentElement {
 typedef OrgDate = ({String year, String month, String day, String? dayName});
 typedef OrgTime = ({String hour, String minute});
 
-sealed class OrgGenericTimestamp extends OrgNode {
+sealed class OrgTimestamp extends OrgNode {
   bool get isActive;
 }
 
 /// A timestamp, like `[2020-05-05 Tue]`
-class OrgSimpleTimestamp extends OrgLeafNode implements OrgGenericTimestamp {
+class OrgSimpleTimestamp extends OrgLeafNode implements OrgTimestamp {
   OrgSimpleTimestamp(
     this.prefix,
     this.date,
@@ -104,8 +104,7 @@ class OrgSimpleTimestamp extends OrgLeafNode implements OrgGenericTimestamp {
       );
 }
 
-class OrgDateRangeTimestamp extends OrgParentNode
-    implements OrgGenericTimestamp {
+class OrgDateRangeTimestamp extends OrgParentNode implements OrgTimestamp {
   OrgDateRangeTimestamp(this.start, this.delimiter, this.end);
 
   final OrgSimpleTimestamp start;
@@ -153,7 +152,7 @@ class OrgDateRangeTimestamp extends OrgParentNode
       );
 }
 
-class OrgTimeRangeTimestamp extends OrgLeafNode implements OrgGenericTimestamp {
+class OrgTimeRangeTimestamp extends OrgLeafNode implements OrgTimestamp {
   OrgTimeRangeTimestamp(
     this.prefix,
     this.date,

--- a/lib/src/org/model/org_timestamp.dart
+++ b/lib/src/org/model/org_timestamp.dart
@@ -14,8 +14,12 @@ class OrgDiaryTimestamp extends OrgLeafNode with SingleContentElement {
 typedef OrgDate = ({String year, String month, String day, String? dayName});
 typedef OrgTime = ({String hour, String minute});
 
+sealed class OrgGenericTimestamp extends OrgNode {
+  bool get isActive;
+}
+
 /// A timestamp, like `[2020-05-05 Tue]`
-class OrgSimpleTimestamp extends OrgLeafNode {
+class OrgSimpleTimestamp extends OrgLeafNode implements OrgGenericTimestamp {
   OrgSimpleTimestamp(
     this.prefix,
     this.date,
@@ -30,6 +34,7 @@ class OrgSimpleTimestamp extends OrgLeafNode {
   final List<String> repeaterOrDelay;
   final String suffix;
 
+  @override
   bool get isActive => prefix == '<' && suffix == '>';
 
   @override
@@ -99,13 +104,15 @@ class OrgSimpleTimestamp extends OrgLeafNode {
       );
 }
 
-class OrgDateRangeTimestamp extends OrgParentNode {
+class OrgDateRangeTimestamp extends OrgParentNode
+    implements OrgGenericTimestamp {
   OrgDateRangeTimestamp(this.start, this.delimiter, this.end);
 
   final OrgSimpleTimestamp start;
   final String delimiter;
   final OrgSimpleTimestamp end;
 
+  @override
   bool get isActive => start.isActive && end.isActive;
 
   @override
@@ -146,7 +153,7 @@ class OrgDateRangeTimestamp extends OrgParentNode {
       );
 }
 
-class OrgTimeRangeTimestamp extends OrgLeafNode {
+class OrgTimeRangeTimestamp extends OrgLeafNode implements OrgGenericTimestamp {
   OrgTimeRangeTimestamp(
     this.prefix,
     this.date,
@@ -163,6 +170,7 @@ class OrgTimeRangeTimestamp extends OrgLeafNode {
   final List<String> repeaterOrDelay;
   final String suffix;
 
+  @override
   bool get isActive => prefix == '<' && suffix == '>';
 
   DateTime get startDateTime => DateTime(

--- a/test/org/model/timestamp_test.dart
+++ b/test/org/model/timestamp_test.dart
@@ -108,5 +108,31 @@ void main() {
       expect(result.contains('あ'), isFalse);
       expect(result.toMarkup(), markup);
     });
+    group("generic timestamp tests", () {
+      test('OrgSimeTimestamp parse', () {
+        final markup = '<2025-05-30>';
+        final result = parser.parse(markup).value as OrgGenericTimestamp;
+
+        expect(result is OrgSimpleTimestamp, isTrue);
+        expect(result is OrgDateRangeTimestamp, isFalse);
+        expect(result is OrgTimeRangeTimestamp, isFalse);
+      });
+      test('OrgSimeTimestamp parse', () {
+        final markup = '<2025-05-30 15:00-16:00>';
+        final result = parser.parse(markup).value as OrgGenericTimestamp;
+
+        expect(result is OrgTimeRangeTimestamp, isTrue);
+        expect(result is OrgSimpleTimestamp, isFalse);
+        expect(result is OrgDateRangeTimestamp, isFalse);
+      });
+      test('OrgSimeTimestamp parse', () {
+        final markup = '<2025-05-30>--<2025-06-30>';
+        final result = parser.parse(markup).value as OrgGenericTimestamp;
+
+        expect(result is OrgDateRangeTimestamp, isTrue);
+        expect(result is OrgSimpleTimestamp, isFalse);
+        expect(result is OrgTimeRangeTimestamp, isFalse);
+      });
+    });
   });
 }

--- a/test/org/model/timestamp_test.dart
+++ b/test/org/model/timestamp_test.dart
@@ -109,29 +109,49 @@ void main() {
       expect(result.toMarkup(), markup);
     });
     group("generic timestamp tests", () {
-      test('OrgSimeTimestamp parse', () {
+      test('OrgSimpleTimestamp', () {
         final markup = '<2025-05-30>';
         final result = parser.parse(markup).value as OrgTimestamp;
 
-        expect(result is OrgSimpleTimestamp, isTrue);
-        expect(result is OrgDateRangeTimestamp, isFalse);
-        expect(result is OrgTimeRangeTimestamp, isFalse);
+        expect(result.isActive, isTrue);
+        expect(result, isA<OrgTimestamp>());
+        expect(result, isA<OrgSimpleTimestamp>());
+        expect(result, isNot(isA<OrgDateRangeTimestamp>()));
+        expect(result, isNot(isA<OrgTimeRangeTimestamp>()));
+        expect(result.toMarkup(), markup);
       });
-      test('OrgSimeTimestamp parse', () {
+      test('OrgTimeRangeTimestamp', () {
         final markup = '<2025-05-30 15:00-16:00>';
         final result = parser.parse(markup).value as OrgTimestamp;
 
-        expect(result is OrgTimeRangeTimestamp, isTrue);
-        expect(result is OrgSimpleTimestamp, isFalse);
-        expect(result is OrgDateRangeTimestamp, isFalse);
+        expect(result.isActive, isTrue);
+        expect(result, isA<OrgTimestamp>());
+        expect(result, isA<OrgTimeRangeTimestamp>());
+        expect(result, isNot(isA<OrgSimpleTimestamp>()));
+        expect(result, isNot(isA<OrgDateRangeTimestamp>()));
+        expect(result.toMarkup(), markup);
       });
-      test('OrgSimeTimestamp parse', () {
-        final markup = '<2025-05-30>--<2025-06-30>';
+      test('OrgDateRangeTimestamp', () {
+        final markup = '[2025-05-30]--[2025-06-30]';
         final result = parser.parse(markup).value as OrgTimestamp;
 
-        expect(result is OrgDateRangeTimestamp, isTrue);
-        expect(result is OrgSimpleTimestamp, isFalse);
-        expect(result is OrgTimeRangeTimestamp, isFalse);
+        expect(result.isActive, isFalse);
+        expect(result, isA<OrgTimestamp>());
+        expect(result, isA<OrgDateRangeTimestamp>());
+        expect(result, isNot(isA<OrgSimpleTimestamp>()));
+        expect(result, isNot(isA<OrgTimeRangeTimestamp>()));
+        expect(result.toMarkup(), markup);
+      });
+      test('Exhaustivity', () {
+        final markup = '[2025-05-30]--[2025-06-30]';
+        final result = parser.parse(markup).value as OrgTimestamp;
+
+        final type = switch (result) {
+          OrgTimeRangeTimestamp() => result.toString(),
+          OrgDateRangeTimestamp() => result.toString(),
+          OrgSimpleTimestamp() => result.toString(),
+        };
+        expect(type, isNotEmpty);
       });
     });
   });

--- a/test/org/model/timestamp_test.dart
+++ b/test/org/model/timestamp_test.dart
@@ -111,7 +111,7 @@ void main() {
     group("generic timestamp tests", () {
       test('OrgSimeTimestamp parse', () {
         final markup = '<2025-05-30>';
-        final result = parser.parse(markup).value as OrgGenericTimestamp;
+        final result = parser.parse(markup).value as OrgTimestamp;
 
         expect(result is OrgSimpleTimestamp, isTrue);
         expect(result is OrgDateRangeTimestamp, isFalse);
@@ -119,7 +119,7 @@ void main() {
       });
       test('OrgSimeTimestamp parse', () {
         final markup = '<2025-05-30 15:00-16:00>';
-        final result = parser.parse(markup).value as OrgGenericTimestamp;
+        final result = parser.parse(markup).value as OrgTimestamp;
 
         expect(result is OrgTimeRangeTimestamp, isTrue);
         expect(result is OrgSimpleTimestamp, isFalse);
@@ -127,7 +127,7 @@ void main() {
       });
       test('OrgSimeTimestamp parse', () {
         final markup = '<2025-05-30>--<2025-06-30>';
-        final result = parser.parse(markup).value as OrgGenericTimestamp;
+        final result = parser.parse(markup).value as OrgTimestamp;
 
         expect(result is OrgDateRangeTimestamp, isTrue);
         expect(result is OrgSimpleTimestamp, isFalse);


### PR DESCRIPTION
This impelements a sealed [1] class which sort of acts as a union tag. This will give us exhaustive switching for every timestamp, like this:

```dart
    section.visit<OrgGenericTimestamp>((node) {
      switch (node) { // => error
          // The type 'OrgGenericTimestamp' is not exhaustively matched by
          // the switch cases since it doesn't match OrgTimeRangeTimestamp()'.

          // do something
          break;

        case OrgSimpleTimestamp():
          // do something
          break;
      }
      return true;
    });
```

Also, because the OrgGenericTimestamp extends OrgNode, we can access toMarkup() and other methods directly from the OrgGenericTimestamp.

[1] https://dart.dev/language/class-modifiers#sealed